### PR TITLE
add tests for replicating with hypercore and with multifeed

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
   "devDependencies": {
     "hypercore": "^8.4.0",
     "hypercore-crypto": "^1.0.0",
+    "multifeed": "^5.1.3",
     "pump": "^3.0.0",
+    "random-access-memory": "^3.1.1",
     "tape": "^4.11.0"
   },
   "dependencies": {
-    "sodium-universal": "^2.0.0",
-    "hypercore-protocol": "^7.7.1"
+    "hypercore-protocol": "^7.7.1",
+    "sodium-universal": "^2.0.0"
   },
   "description": ""
 }

--- a/test.js
+++ b/test.js
@@ -3,6 +3,9 @@ const Protocol = require('hypercore-protocol')
 const crypto = require('hypercore-crypto')
 const { pipeline } = require('stream')
 const authenticatedProtocol = require('.')
+const hypercore = require('hypercore')
+const ram = require('random-access-memory')
+const multifeed = require('multifeed')
 
 tape('basics', t => {
   t.plan(2)
@@ -34,6 +37,103 @@ tape('basics', t => {
       onprotocol (protocol) {
         // This is where you'd initialiize the actual connection.
         t.ok(protocol)
+      }
+    })
+    return protocol
+  }
+})
+
+tape('with replication of a hypercore', t => {
+  const auth1 = crypto.keyPair()
+  const auth2 = crypto.keyPair()
+
+  const feed1 = hypercore(ram)
+  feed1.on('ready', () => {
+    const feed2 = hypercore(ram, feed1.key)
+    feed1.append(Buffer.from('boop'), (err, seq) => {
+      t.error(err, 'No error on append')
+      const stream1 = init(true, auth1, 'one', feed1)
+      const stream2 = init(false, auth2, 'two', feed2)
+      stream1.pipe(stream2).pipe(stream1)
+      stream1.on('error', (err) => {
+        console.log(err)
+      })
+      stream1.on('end', () => {
+        t.error(err, 'no error on replicate')
+        t.ok(feed2.length, 'feed has replicated')
+        t.end()
+      })
+    })
+  })
+
+  function init (isInitiator, authKeyPair, name, feed) {
+    const protocol = new Protocol(isInitiator)
+    authenticatedProtocol(protocol, {
+      authKeyPair,
+      onauthenticate (publicKey, cb) {
+        if (name === 'one' && publicKey.equals(auth2.publicKey)) {
+          return cb(null, true)
+        }
+        if (name === 'two' && publicKey.equals(auth1.publicKey)) {
+          return cb(null, true)
+        }
+        cb(null, false)
+      },
+      onprotocol (protocol) {
+        t.ok(protocol, 'Protocol ok')
+        feed.replicate(isInitiator, { stream: protocol })
+      }
+    })
+    return protocol
+  }
+})
+
+tape('using multifeed', t => {
+  const auth1 = crypto.keyPair()
+  const auth2 = crypto.keyPair()
+
+  const multi1 = multifeed(ram)
+  const multi2 = multifeed(ram)
+
+  multi1.writer('test', (err, feed1) => {
+    t.error(err, 'No error on create writer')
+    feed1.append(Buffer.from('boop'), (err, seq) => {
+      t.error(err, 'No error on append')
+      const stream1 = init(true, auth1, 'one', multi1)
+      const stream2 = init(false, auth2, 'two', multi2)
+      stream1.pipe(stream2).pipe(stream1)
+      stream1.on('error', (err) => {
+        console.log(err)
+      })
+      stream1.on('end', () => {
+        t.error(err, 'no error on replicate')
+        multi2.feeds()[0].get(0, (err, data) => {
+          t.error(err, 'no error on get')
+          t.equals(data.toString(), 'boop', 'data has replicated')
+          t.end()
+        })
+      })
+    })
+  })
+
+  function init (isInitiator, authKeyPair, name, multifeed) {
+    const protocol = new Protocol(isInitiator)
+    authenticatedProtocol(protocol, {
+      authKeyPair,
+      onauthenticate (publicKey, cb) {
+        if (name === 'one' && publicKey.equals(auth2.publicKey)) {
+          return cb(null, true)
+        }
+        if (name === 'two' && publicKey.equals(auth1.publicKey)) {
+          return cb(null, true)
+        }
+        cb(null, false)
+      },
+      onprotocol (protocol) {
+        t.ok(protocol, 'Protocol ok')
+        // multifeed.replicate() will not take a stream as an option
+        // so this doesn't work
+        multifeed.replicate(isInitiator, { stream: protocol })
       }
     })
     return protocol


### PR DESCRIPTION
i dont actually want to merge this, at least for now, but here are some additional tests, one of which fails, to demonstrate a difficulty with using this.

to replicate after authenticating we can pass the `hypercore-protocol` stream into the replication method with `opts.stream = protocolStream`. This works great with an individual hypercore, but `multifeed`'s `replicate` method doesnt take a stream as an option.

I am considering making a PR to multifeed to allow this, and maybe i would use these tests to help explain why it would be useful.  But maybe there is actually an easier way to go about this. @Frando 